### PR TITLE
Shrink nav buttons so all 7 fit on a single row

### DIFF
--- a/archive-infotainment-app.html
+++ b/archive-infotainment-app.html
@@ -84,8 +84,8 @@
 
         .main-nav {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-            gap: 20px;
+            grid-template-columns: repeat(7, 1fr);
+            gap: 15px;
             margin-bottom: 50px;
             max-width: 1200px;
             margin-left: auto;
@@ -93,7 +93,7 @@
         }
 
         .nav-btn {
-            padding: 30px 20px;
+            padding: 20px 10px;
             background: rgba(255, 255, 255, 0.05);
             backdrop-filter: blur(10px);
             border: 1px solid rgba(0, 255, 255, 0.2);
@@ -142,8 +142,8 @@
         }
 
         .nav-icon {
-            font-size: 2em;
-            margin-bottom: 10px;
+            font-size: 1.6em;
+            margin-bottom: 8px;
             display: block;
         }
 


### PR DESCRIPTION
- Use fixed repeat(7, 1fr) grid instead of auto-fit minmax(180px)
- Reduce button padding (30px/20px -> 20px/10px) and gap (20px -> 15px)
- Slightly smaller nav icons (2em -> 1.6em)
- Mobile breakpoint still falls back to 2-column layout

https://claude.ai/code/session_01AteJETFTCj5gKSraAX5PcG